### PR TITLE
Fixed "Plugin with id 'com.android.library' not found"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,10 @@ buildscript {
 	repositories {
 		jcenter()
 	}
+
+	dependencies {
+		classpath 'com.android.tools.build:gradle:2.2.3'
+	}
 }
 
 allprojects {


### PR DESCRIPTION
This library would build fine when used as a dependency of another project. However, when this project is built on it's own you receive the gradle build error "Plugin with id'com.android.library' not found".

![before](https://cloud.githubusercontent.com/assets/6881571/24453096/5b454918-147e-11e7-9480-de1898d430a8.png)

This is causing errors because:
- The gradle dependency is missing from the project `build.gradle`
- This would have worked fine when it is used as a dependency, because the parent project probably had gradle set as a project dependency

By adding in the gradle dependency, it now fixes the error:

![after](https://cloud.githubusercontent.com/assets/6881571/24453152/9ae597f8-147e-11e7-9c8f-808fc35cccb2.png)