### PR TITLE
Switched to use grey borders for pickers

### DIFF
--- a/views/src/main/java/com/lush/view/spinner/BaseLushSpinner.java
+++ b/views/src/main/java/com/lush/view/spinner/BaseLushSpinner.java
@@ -96,7 +96,7 @@ public abstract class BaseLushSpinner<T> extends Spinner implements AdapterView.
 
 	private void applyStyle()
 	{
-		setBackgroundResource(R.drawable.bg_outline_black);
+		setBackgroundResource(R.drawable.bg_outline_light_grey);
 	}
 
 	public T getSelected()

--- a/views/src/main/res/drawable/bg_outline_light_grey.xml
+++ b/views/src/main/res/drawable/bg_outline_light_grey.xml
@@ -4,6 +4,11 @@
 	android:shape="rectangle">
 
 	<corners android:radius="1dp" />
-	<stroke android:width="1dp" android:color="@color/light_grey" />
+	<stroke android:width="2dp" android:color="@color/light_grey" />
+	<padding android:left="2dp"
+			 android:top="2dp"
+			 android:right="2dp"
+			 android:bottom="2dp" />
+	<solid android:color="@android:color/white" />
 
 </shape>

--- a/views/src/main/res/layout/view_quantity.xml
+++ b/views/src/main/res/layout/view_quantity.xml
@@ -5,7 +5,7 @@
 	android:layout_width="match_parent"
 	android:layout_height="wrap_content"
 	android:padding="4dp"
-	android:background="@drawable/bg_outline_black">
+	android:background="@drawable/bg_outline_light_grey">
 
 	<ImageView
 		android:id="@+id/minus"

--- a/views/src/main/res/layout/view_quantity_spinner.xml
+++ b/views/src/main/res/layout/view_quantity_spinner.xml
@@ -6,4 +6,4 @@
 	android:layout_height="wrap_content"
 	android:minWidth="96dp"
 	android:textAppearance="@style/Text.Black"
-	android:background="@drawable/bg_outline_black"/>
+	android:background="@drawable/bg_outline_light_grey"/>


### PR DESCRIPTION
Now using grey borders for:
- Generic pickers
- Quantity views/spinners

Which have been updated to match the black one we are currently using

For more information see the [design review](https://projects.invisionapp.com/boards/D93DIH8URQFYM/#/5669324/170480724)

FYI: The grey used in `bg_outline_line_grey` is `#EAEAEA` as requested in the designs. 
*Not to be confused with the terrible games company*