### PR TITLE
Updated support library to 27.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ task clean(type: Delete) {
 }
 
 ext {
-	supportlib_version = '26.1.0'
+	supportlib_version = '27.0.0'
 	kotlin_version = '1.1.51'
 }
 

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -2,13 +2,13 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 android {
-	compileSdkVersion 26
+	compileSdkVersion 27
 	buildToolsVersion "26.0.2"
 
 	defaultConfig {
 		applicationId "com.lush.views"
 		minSdkVersion 16
-		targetSdkVersion 26
+		targetSdkVersion 27
 		versionCode 1
 		versionName "1.0"
 

--- a/views/build.gradle
+++ b/views/build.gradle
@@ -31,7 +31,6 @@ dependencies {
 	compile "com.android.support:recyclerview-v7:$supportlib_version"
 	compile "com.android.support:transition:$supportlib_version"
 	compile "com.android.support:support-annotations:$supportlib_version"
-	compile "com.android.support:support-v4:$supportlib_version"
 
 	compile 'uk.co.chrisjenx:calligraphy:2.3.0', {
 		exclude group: 'com.android.support'

--- a/views/build.gradle
+++ b/views/build.gradle
@@ -4,11 +4,11 @@ apply plugin: 'com.android.library'
 apply plugin: 'com.lush.deploy'
 
 android {
-	compileSdkVersion 26
+	compileSdkVersion 27
 	buildToolsVersion "26.0.2"
 	defaultConfig {
 		minSdkVersion 16
-		targetSdkVersion 26
+		targetSdkVersion 27
 		versionCode 1
 		versionName version
 		testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"

--- a/views/build.gradle
+++ b/views/build.gradle
@@ -23,13 +23,55 @@ android {
 
 dependencies {
 	compile fileTree(dir: 'libs', include: ['*.jar'])
+
+	// Let's ensure that we are using only one support library version
+	compile "com.android.support:design:$supportlib_version"
+	compile "com.android.support:support-v4:$supportlib_version"
 	compile "com.android.support:appcompat-v7:$supportlib_version"
-	compile 'uk.co.chrisjenx:calligraphy:2.3.0'
-	compile 'com.github.matt-allen:Android-Universal-Image-Loader:2.1.2'
-	compile 'com.yqritc:android-scalablevideoview:1.0.4'
 	compile "com.android.support:recyclerview-v7:$supportlib_version"
+	compile "com.android.support:transition:$supportlib_version"
+	compile "com.android.support:support-annotations:$supportlib_version"
+	compile "com.android.support:support-v4:$supportlib_version"
+
+	compile 'uk.co.chrisjenx:calligraphy:2.3.0', {
+		exclude group: 'com.android.support', module: 'design'
+		exclude group: 'com.android.support', module: 'support-v4'
+		exclude group: 'com.android.support', module: 'appcompat-v7'
+		exclude group: 'com.android.support', module: 'recyclerview-v7'
+		exclude group: 'com.android.support', module: 'transition'
+		exclude group: 'com.android.support', module: 'support-annotations'
+		exclude group: 'com.android.support', module: 'support-v4'
+	}
+
+	compile 'com.github.matt-allen:Android-Universal-Image-Loader:2.1.2', {
+		exclude group: 'com.android.support', module: 'design'
+		exclude group: 'com.android.support', module: 'support-v4'
+		exclude group: 'com.android.support', module: 'appcompat-v7'
+		exclude group: 'com.android.support', module: 'recyclerview-v7'
+		exclude group: 'com.android.support', module: 'transition'
+		exclude group: 'com.android.support', module: 'support-annotations'
+		exclude group: 'com.android.support', module: 'support-v4'
+	}
+
+	compile 'com.yqritc:android-scalablevideoview:1.0.4', {
+		exclude group: 'com.android.support', module: 'design'
+		exclude group: 'com.android.support', module: 'support-v4'
+		exclude group: 'com.android.support', module: 'appcompat-v7'
+		exclude group: 'com.android.support', module: 'recyclerview-v7'
+		exclude group: 'com.android.support', module: 'transition'
+		exclude group: 'com.android.support', module: 'support-annotations'
+		exclude group: 'com.android.support', module: 'support-v4'
+	}
 
 	// This is the last version of AHBottomNavigation before you were forced to use the new google bottom nav bar design, which we don't want to use
 	// Keep this version to ensure that you can force all tab text to show at once
-	compile 'com.aurelhubert:ahbottomnavigation:1.3.3'
+	compile 'com.aurelhubert:ahbottomnavigation:1.3.3', {
+		exclude group: 'com.android.support', module: 'design'
+		exclude group: 'com.android.support', module: 'support-v4'
+		exclude group: 'com.android.support', module: 'appcompat-v7'
+		exclude group: 'com.android.support', module: 'recyclerview-v7'
+		exclude group: 'com.android.support', module: 'transition'
+		exclude group: 'com.android.support', module: 'support-annotations'
+		exclude group: 'com.android.support', module: 'support-v4'
+	}
 }

--- a/views/build.gradle
+++ b/views/build.gradle
@@ -34,44 +34,20 @@ dependencies {
 	compile "com.android.support:support-v4:$supportlib_version"
 
 	compile 'uk.co.chrisjenx:calligraphy:2.3.0', {
-		exclude group: 'com.android.support', module: 'design'
-		exclude group: 'com.android.support', module: 'support-v4'
-		exclude group: 'com.android.support', module: 'appcompat-v7'
-		exclude group: 'com.android.support', module: 'recyclerview-v7'
-		exclude group: 'com.android.support', module: 'transition'
-		exclude group: 'com.android.support', module: 'support-annotations'
-		exclude group: 'com.android.support', module: 'support-v4'
+		exclude group: 'com.android.support'
 	}
 
 	compile 'com.github.matt-allen:Android-Universal-Image-Loader:2.1.2', {
-		exclude group: 'com.android.support', module: 'design'
-		exclude group: 'com.android.support', module: 'support-v4'
-		exclude group: 'com.android.support', module: 'appcompat-v7'
-		exclude group: 'com.android.support', module: 'recyclerview-v7'
-		exclude group: 'com.android.support', module: 'transition'
-		exclude group: 'com.android.support', module: 'support-annotations'
-		exclude group: 'com.android.support', module: 'support-v4'
+		exclude group: 'com.android.support'
 	}
 
 	compile 'com.yqritc:android-scalablevideoview:1.0.4', {
-		exclude group: 'com.android.support', module: 'design'
-		exclude group: 'com.android.support', module: 'support-v4'
-		exclude group: 'com.android.support', module: 'appcompat-v7'
-		exclude group: 'com.android.support', module: 'recyclerview-v7'
-		exclude group: 'com.android.support', module: 'transition'
-		exclude group: 'com.android.support', module: 'support-annotations'
-		exclude group: 'com.android.support', module: 'support-v4'
+		exclude group: 'com.android.support'
 	}
 
 	// This is the last version of AHBottomNavigation before you were forced to use the new google bottom nav bar design, which we don't want to use
 	// Keep this version to ensure that you can force all tab text to show at once
 	compile 'com.aurelhubert:ahbottomnavigation:1.3.3', {
-		exclude group: 'com.android.support', module: 'design'
-		exclude group: 'com.android.support', module: 'support-v4'
-		exclude group: 'com.android.support', module: 'appcompat-v7'
-		exclude group: 'com.android.support', module: 'recyclerview-v7'
-		exclude group: 'com.android.support', module: 'transition'
-		exclude group: 'com.android.support', module: 'support-annotations'
-		exclude group: 'com.android.support', module: 'support-v4'
+		exclude group: 'com.android.support'
 	}
 }

--- a/views/build.gradle
+++ b/views/build.gradle
@@ -1,4 +1,4 @@
-version = '1.21'
+version = '1.22'
 group = 'com.lush.library'
 apply plugin: 'com.android.library'
 apply plugin: 'com.lush.deploy'


### PR DESCRIPTION
- Now forcing the support library version to prevent issues with different support versions being used across dependencies
- Compile and target sdk will need to be bumped in any projects that want to use this version